### PR TITLE
Update the IdentityApi.md document example

### DIFF
--- a/docs/Api/IdentityApi.md
+++ b/docs/Api/IdentityApi.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 # **getConnections**
 > \XeroAPI\XeroPHP\Models\Identity\Connection[] getConnections()
 
-Allows you to retrieve the connections for this users
+Allows you to retrieve the connections for user
 
 Override the base server url that include version
 
@@ -19,10 +19,17 @@ Override the base server url that include version
 <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
+$accessToken = '';
+
+$config = \XeroAPI\XeroPHP\Configuration::getDefaultConfiguration()->setAccessToken( (string)$accessToken );
+
+$config->setHost('https://api.xero.com');
+
 $apiInstance = new XeroAPI\XeroPHP\Api\IdentityApi(
     // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
     // This is optional, `GuzzleHttp\Client` will be used as default.
-    new GuzzleHttp\Client()
+    new \GuzzleHttp\Client(),
+	$config
 );
 
 try {


### PR DESCRIPTION
Grammar correction

Update the IdentityApi.md document to include the $config object to show how to provide an access token for an authorised user (improves example for new developers). Without providing access token, response is

`Exception when calling IdentityApi->getConnections: [401] Client error: GET https://api.xero.com/connections resulted in a 401 Unauthorized`

Update the Class namespaces (vendor classes) in example with prefixed slash so name spacing is not confused with current namespace if code is copied into a class with an existing namespace. Alternative is to add `use` instead to import the class and drop the namespaces part of class