### PR TITLE
Fix: getToken() incorrectly returning null session

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ class StorageClass
 	public function getToken()
 	{
 	    //If it doesn't exist or is expired, return null
-	    if (!empty($this->getSession())
+	    if (empty($this->getSession())
 	        || ($_SESSION['oauth2']['expires'] !== null
 	        && $_SESSION['oauth2']['expires'] <= time())
 	    ) {


### PR DESCRIPTION
Fixes issue with example storage class in README file.

`getToken` method should only return a null value if the session does not exist or the session token has expired.