### PR TITLE
Fixes - https://github.com/XeroAPI/xero-php-oauth2/issues/150. Sid is…

### DIFF
--- a/lib/JWTClaims.php
+++ b/lib/JWTClaims.php
@@ -42,7 +42,9 @@ class JWTClaims
             $this->auth_time = $this->jwtDecoded->{'auth_time'};
             $this->iss = $this->jwtDecoded->{'iss'};
             $this->at_hash = $this->jwtDecoded->{'at_hash'};
-            $this->sid = $this->jwtDecoded->{'sid'};
+
+            // not every jwt token seems to contain this key!
+            $this->sid = isset($this->jwtDecoded->{'sid'}) ? $this->jwtDecoded->{'sid'} : null;
         
             // No idea why these values can't be read
             //but appear when dumping jwtDecoded?!?!


### PR DESCRIPTION
… not always present in the decoded token.

This resolves https://github.com/XeroAPI/xero-php-oauth2/issues/150 and https://github.com/webfox/laravel-xero-oauth2/issues/39.