### PR TITLE
Fix incorrect host for Files API

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -136,7 +136,7 @@ class Configuration
      *
      * @var string
      */
-    protected $hostFile = 'https://api.xero.com/file.xro/1.0';
+    protected $hostFile = 'https://api.xero.com/files.xro/1.0';
     
     /**
      * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default


### PR DESCRIPTION
This was pointing to https://api.xero.com/file.xro/1.0, according to docs (and testing) should be https://api.xero.com/files.xro/1.0 (with an s). Presumably this has never worked, and more worryingly, never been tested.