### PR TITLE
Correct timezone conversion.

### DIFF
--- a/lib/StringUtil.php
+++ b/lib/StringUtil.php
@@ -48,7 +48,7 @@ class StringUtil
                 $seconds = $date[1]/1000;
             }
             
-            $dateString = date("d-m-Y", $seconds);
+            $dateString = (new \DateTime('@' . $seconds))->format('d-m-Y');
             $dateFormat = new \DateTime($dateString);
             return $dateFormat;
         }

--- a/lib/StringUtil.php
+++ b/lib/StringUtil.php
@@ -6,7 +6,7 @@
  * @category Class
  * @package  XeroAPI\XeroPHP
  * @author   Xero API team
- * @link     
+ * @link
  */
 
 namespace XeroAPI\XeroPHP;
@@ -47,7 +47,7 @@ class StringUtil
             if($match){
                 $seconds = $date[1]/1000;
             }
-            
+
             $dateString = (new \DateTime('@' . $seconds))->format('d-m-Y');
             $dateFormat = new \DateTime($dateString);
             return $dateFormat;
@@ -60,7 +60,7 @@ class StringUtil
         if( self::checkThisDate($data) ) {
             return new \DateTime($data);
         } else {
-           
+
             // Data not in a format that simply converts to a new DateTime();
             // Custom Date Deserializer to allow for Xero's use of .NET JSON Date format
             $match = preg_match( '/([\d]{11})/', $data, $date );
@@ -75,18 +75,18 @@ class StringUtil
             if($match){
                 $seconds = $date[1]/1000;
             }
-            
+
             $datetime = new \DateTime();
             $datetime->setTimestamp($seconds);
-    
+
             $result = $datetime->format('Y-m-d H:i:s');
-                
+
             $date = new \DateTime($result);
             return $date;
         }
     }
 
-    public static function checkThisDate($value) 
+    public static function checkThisDate($value)
     {
         if (!$value) {
             return false;


### PR DESCRIPTION
The `convertStringToDate` function doesn't handle the timezone difference. For example, for April 1, 2021, you incorrectly get March 31, 2021.

```php
>>> $seconds = 1617235200000 / 1000
=> 1617235200
>>> $dateString = date("d-m-Y", $seconds)
=> "31-03-2021"
>>> $dateFormat = new \DateTime($dateString)
=> DateTime @1617163200 {#3743
     date: 2021-03-31 00:00:00.0 America/New_York (-04:00),
   }
```

This change corrects the behavior:

```php
>>> $seconds = 1617235200000 / 1000
=> 1617235200
>>> $dateString = (new \DateTime('@' . $seconds))->format('d-m-Y')
=> "01-04-2021"
>>> $dateFormat = new \DateTime($dateString)
=> DateTime @1617249600 {#3744
     date: 2021-04-01 00:00:00.0 America/New_York (-04:00),
   }
```