### PR TITLE
Fix SplFileObject handling

### DIFF
--- a/lib/AccountingObjectSerializer.php
+++ b/lib/AccountingObjectSerializer.php
@@ -308,9 +308,6 @@ class AccountingObjectSerializer
             } else {
                 return null;
             }
-        } elseif (in_array($class, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
-            settype($data, $class);
-            return $data;
         } elseif ($class === '\SplFileObject') {
             /** @var \Psr\Http\Message\StreamInterface $data */
 
@@ -329,6 +326,9 @@ class AccountingObjectSerializer
             fclose($file);
 
             return new \SplFileObject($filename, 'r');
+        } elseif (in_array($class, ['\DateTime', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+            settype($data, $class);
+            return $data;
         } elseif (method_exists($class, 'getAllowableEnumValues')) {
             if (!in_array($data, $class::getAllowableEnumValues(), true)) {
                 $imploded = implode("', '", $class::getAllowableEnumValues());


### PR DESCRIPTION
This fixes an issue introduced in 2.13.0. `SplFileObject` is handled in the `is_array` check, which will try to use `settype` on the `SplFileObject`, which turns into a `ValueError`

`settype(): Argument #2 ($type) must be a valid type`

By placing the `SplFileObject` earlier, that fixes the issue.

I know this isn't the right solution, i.e. it should be generated from the OpenAPI spec, but I was unable to find how best to regenerate it, as it seems already fixed on the openapi-generator, so opened this PR for discussion.