### PR TITLE
Accounting docs typo fix

### DIFF
--- a/docs/v2/accounting/index.html
+++ b/docs/v2/accounting/index.html
@@ -11292,7 +11292,7 @@ $lineItem->setDescription('Foobar');
 $lineItem->setQuantity(1.0);
 $lineItem->setUnitAmount(20.0);
 $lineItem->setAccountCode('000');
-$lineItem->setTracking(lineItemTrackings);
+$lineItem->setTracking($lineItemTrackings);
 $lineItems = [];
 array_push($lineItems, $lineItem);
 


### PR DESCRIPTION
This is a minor typo fix suggestion for the accounting docs.

`lineItemTrackings` should be `$lineItemTrackings`.