### PR TITLE
fix: remove 5.x support and update decode method signature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.2 | ^7.0",
         "league/oauth2-client": "^2.5.0",
-        "firebase/php-jwt": "^5.0 | ^6.0"
+        "firebase/php-jwt": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/lib/JWTClaims.php
+++ b/lib/JWTClaims.php
@@ -36,8 +36,7 @@ class JWTClaims
     private function verify($token) {
         $json = file_get_contents('https://identity.xero.com/.well-known/openid-configuration/jwks');
         $jwks =  json_decode($json, true);
-        $supportedAlgorithm = array('RS256');
-        $verifiedJWT = JWT::decode($token, JWK::parseKeySet($jwks), $supportedAlgorithm);
+        $verifiedJWT = JWT::decode($token, JWK::parseKeySet($jwks));
 
         return $verifiedJWT;
     }


### PR DESCRIPTION
See advisory: [Firebase PHP-JWT key/algorithm type confusion](https://github.com/advisories/GHSA-8xf4-w7qw-pjjw)

There's also an issue where the two versions of jwt-php have different method signatures for the `JWT::decode` method. In version 6 supported algorithms are no longer given as a third parameters.

`JWK::parseKeySet` already returns a properly formatted array of keys.

https://github.com/firebase/php-jwt/tree/main#using-jwks