### PR TITLE
Add PHPDocs for count(), getIterator(), and jsonSerialize()

### DIFF
--- a/lib/Models/Accounting/Accounts.php
+++ b/lib/Models/Accounting/Accounts.php
@@ -159,9 +159,9 @@ class Accounts implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Accounts implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['accounts'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['accounts']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['accounts']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Actions.php
+++ b/lib/Models/Accounting/Actions.php
@@ -159,9 +159,9 @@ class Actions implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Actions implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         unset($this->container['actions'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['actions']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['actions']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Allocations.php
+++ b/lib/Models/Accounting/Allocations.php
@@ -159,9 +159,9 @@ class Allocations implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Allocations implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         unset($this->container['allocations'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['allocations']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['allocations']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Attachments.php
+++ b/lib/Models/Accounting/Attachments.php
@@ -159,9 +159,9 @@ class Attachments implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Attachments implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         unset($this->container['attachments'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['attachments']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['attachments']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/BankTransactions.php
+++ b/lib/Models/Accounting/BankTransactions.php
@@ -159,9 +159,9 @@ class BankTransactions implements ModelInterface, ArrayAccess, \Countable, \Iter
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class BankTransactions implements ModelInterface, ArrayAccess, \Countable, \Iter
         unset($this->container['bank_transactions'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['bank_transactions']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['bank_transactions']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/BankTransfers.php
+++ b/lib/Models/Accounting/BankTransfers.php
@@ -159,9 +159,9 @@ class BankTransfers implements ModelInterface, ArrayAccess, \Countable, \Iterato
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class BankTransfers implements ModelInterface, ArrayAccess, \Countable, \Iterato
         unset($this->container['bank_transfers'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['bank_transfers']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['bank_transfers']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/BatchPayments.php
+++ b/lib/Models/Accounting/BatchPayments.php
@@ -159,9 +159,9 @@ class BatchPayments implements ModelInterface, ArrayAccess, \Countable, \Iterato
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class BatchPayments implements ModelInterface, ArrayAccess, \Countable, \Iterato
         unset($this->container['batch_payments'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['batch_payments']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['batch_payments']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/BrandingThemes.php
+++ b/lib/Models/Accounting/BrandingThemes.php
@@ -159,9 +159,9 @@ class BrandingThemes implements ModelInterface, ArrayAccess, \Countable, \Iterat
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class BrandingThemes implements ModelInterface, ArrayAccess, \Countable, \Iterat
         unset($this->container['branding_themes'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['branding_themes']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['branding_themes']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Budgets.php
+++ b/lib/Models/Accounting/Budgets.php
@@ -159,9 +159,9 @@ class Budgets implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Budgets implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         unset($this->container['budgets'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['budgets']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['budgets']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/CISOrgSettings.php
+++ b/lib/Models/Accounting/CISOrgSettings.php
@@ -159,9 +159,9 @@ class CISOrgSettings implements ModelInterface, ArrayAccess, \Countable, \Iterat
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class CISOrgSettings implements ModelInterface, ArrayAccess, \Countable, \Iterat
         unset($this->container['cis_settings'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['cis_settings']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['cis_settings']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/CISSettings.php
+++ b/lib/Models/Accounting/CISSettings.php
@@ -159,9 +159,9 @@ class CISSettings implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class CISSettings implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         unset($this->container['cis_settings'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['cis_settings']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['cis_settings']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/ContactGroups.php
+++ b/lib/Models/Accounting/ContactGroups.php
@@ -159,9 +159,9 @@ class ContactGroups implements ModelInterface, ArrayAccess, \Countable, \Iterato
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class ContactGroups implements ModelInterface, ArrayAccess, \Countable, \Iterato
         unset($this->container['contact_groups'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['contact_groups']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['contact_groups']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Contacts.php
+++ b/lib/Models/Accounting/Contacts.php
@@ -159,9 +159,9 @@ class Contacts implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Contacts implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['contacts'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['contacts']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['contacts']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/CreditNotes.php
+++ b/lib/Models/Accounting/CreditNotes.php
@@ -159,9 +159,9 @@ class CreditNotes implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class CreditNotes implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         unset($this->container['credit_notes'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['credit_notes']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['credit_notes']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Currencies.php
+++ b/lib/Models/Accounting/Currencies.php
@@ -159,9 +159,9 @@ class Currencies implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Currencies implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         unset($this->container['currencies'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['currencies']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['currencies']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Employees.php
+++ b/lib/Models/Accounting/Employees.php
@@ -159,9 +159,9 @@ class Employees implements ModelInterface, ArrayAccess, \Countable, \IteratorAgg
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Employees implements ModelInterface, ArrayAccess, \Countable, \IteratorAgg
         unset($this->container['employees'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['employees']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['employees']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/ExpenseClaims.php
+++ b/lib/Models/Accounting/ExpenseClaims.php
@@ -159,9 +159,9 @@ class ExpenseClaims implements ModelInterface, ArrayAccess, \Countable, \Iterato
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class ExpenseClaims implements ModelInterface, ArrayAccess, \Countable, \Iterato
         unset($this->container['expense_claims'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['expense_claims']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['expense_claims']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/HistoryRecords.php
+++ b/lib/Models/Accounting/HistoryRecords.php
@@ -159,9 +159,9 @@ class HistoryRecords implements ModelInterface, ArrayAccess, \Countable, \Iterat
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class HistoryRecords implements ModelInterface, ArrayAccess, \Countable, \Iterat
         unset($this->container['history_records'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['history_records']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['history_records']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/InvoiceReminders.php
+++ b/lib/Models/Accounting/InvoiceReminders.php
@@ -159,9 +159,9 @@ class InvoiceReminders implements ModelInterface, ArrayAccess, \Countable, \Iter
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class InvoiceReminders implements ModelInterface, ArrayAccess, \Countable, \Iter
         unset($this->container['invoice_reminders'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['invoice_reminders']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['invoice_reminders']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Invoices.php
+++ b/lib/Models/Accounting/Invoices.php
@@ -159,9 +159,9 @@ class Invoices implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Invoices implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['invoices'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['invoices']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['invoices']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Items.php
+++ b/lib/Models/Accounting/Items.php
@@ -159,9 +159,9 @@ class Items implements ModelInterface, ArrayAccess, \Countable, \IteratorAggrega
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Items implements ModelInterface, ArrayAccess, \Countable, \IteratorAggrega
         unset($this->container['items'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['items']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['items']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Journals.php
+++ b/lib/Models/Accounting/Journals.php
@@ -159,9 +159,9 @@ class Journals implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Journals implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['journals'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['journals']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['journals']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/LinkedTransactions.php
+++ b/lib/Models/Accounting/LinkedTransactions.php
@@ -159,9 +159,9 @@ class LinkedTransactions implements ModelInterface, ArrayAccess, \Countable, \It
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class LinkedTransactions implements ModelInterface, ArrayAccess, \Countable, \It
         unset($this->container['linked_transactions'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['linked_transactions']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['linked_transactions']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/ManualJournals.php
+++ b/lib/Models/Accounting/ManualJournals.php
@@ -159,9 +159,9 @@ class ManualJournals implements ModelInterface, ArrayAccess, \Countable, \Iterat
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class ManualJournals implements ModelInterface, ArrayAccess, \Countable, \Iterat
         unset($this->container['manual_journals'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['manual_journals']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['manual_journals']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/OnlineInvoices.php
+++ b/lib/Models/Accounting/OnlineInvoices.php
@@ -159,9 +159,9 @@ class OnlineInvoices implements ModelInterface, ArrayAccess, \Countable, \Iterat
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class OnlineInvoices implements ModelInterface, ArrayAccess, \Countable, \Iterat
         unset($this->container['online_invoices'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['online_invoices']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['online_invoices']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Organisations.php
+++ b/lib/Models/Accounting/Organisations.php
@@ -159,9 +159,9 @@ class Organisations implements ModelInterface, ArrayAccess, \Countable, \Iterato
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Organisations implements ModelInterface, ArrayAccess, \Countable, \Iterato
         unset($this->container['organisations'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['organisations']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['organisations']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Overpayments.php
+++ b/lib/Models/Accounting/Overpayments.php
@@ -159,9 +159,9 @@ class Overpayments implements ModelInterface, ArrayAccess, \Countable, \Iterator
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Overpayments implements ModelInterface, ArrayAccess, \Countable, \Iterator
         unset($this->container['overpayments'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['overpayments']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['overpayments']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/PaymentServices.php
+++ b/lib/Models/Accounting/PaymentServices.php
@@ -159,9 +159,9 @@ class PaymentServices implements ModelInterface, ArrayAccess, \Countable, \Itera
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class PaymentServices implements ModelInterface, ArrayAccess, \Countable, \Itera
         unset($this->container['payment_services'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['payment_services']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['payment_services']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Payments.php
+++ b/lib/Models/Accounting/Payments.php
@@ -159,9 +159,9 @@ class Payments implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Payments implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['payments'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['payments']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['payments']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Prepayments.php
+++ b/lib/Models/Accounting/Prepayments.php
@@ -159,9 +159,9 @@ class Prepayments implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Prepayments implements ModelInterface, ArrayAccess, \Countable, \IteratorA
         unset($this->container['prepayments'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['prepayments']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['prepayments']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/PurchaseOrders.php
+++ b/lib/Models/Accounting/PurchaseOrders.php
@@ -159,9 +159,9 @@ class PurchaseOrders implements ModelInterface, ArrayAccess, \Countable, \Iterat
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class PurchaseOrders implements ModelInterface, ArrayAccess, \Countable, \Iterat
         unset($this->container['purchase_orders'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['purchase_orders']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['purchase_orders']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Quotes.php
+++ b/lib/Models/Accounting/Quotes.php
@@ -159,9 +159,9 @@ class Quotes implements ModelInterface, ArrayAccess, \Countable, \IteratorAggreg
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Quotes implements ModelInterface, ArrayAccess, \Countable, \IteratorAggreg
         unset($this->container['quotes'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['quotes']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['quotes']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Receipts.php
+++ b/lib/Models/Accounting/Receipts.php
@@ -159,9 +159,9 @@ class Receipts implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Receipts implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['receipts'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['receipts']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['receipts']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/RepeatingInvoices.php
+++ b/lib/Models/Accounting/RepeatingInvoices.php
@@ -159,9 +159,9 @@ class RepeatingInvoices implements ModelInterface, ArrayAccess, \Countable, \Ite
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class RepeatingInvoices implements ModelInterface, ArrayAccess, \Countable, \Ite
         unset($this->container['repeating_invoices'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['repeating_invoices']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['repeating_invoices']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Reports.php
+++ b/lib/Models/Accounting/Reports.php
@@ -159,9 +159,9 @@ class Reports implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Reports implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         unset($this->container['reports'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['reports']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['reports']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/TaxRates.php
+++ b/lib/Models/Accounting/TaxRates.php
@@ -159,9 +159,9 @@ class TaxRates implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class TaxRates implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['tax_rates'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['tax_rates']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['tax_rates']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/TrackingCategories.php
+++ b/lib/Models/Accounting/TrackingCategories.php
@@ -159,9 +159,9 @@ class TrackingCategories implements ModelInterface, ArrayAccess, \Countable, \It
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class TrackingCategories implements ModelInterface, ArrayAccess, \Countable, \It
         unset($this->container['tracking_categories'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['tracking_categories']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['tracking_categories']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/TrackingOptions.php
+++ b/lib/Models/Accounting/TrackingOptions.php
@@ -159,9 +159,9 @@ class TrackingOptions implements ModelInterface, ArrayAccess, \Countable, \Itera
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class TrackingOptions implements ModelInterface, ArrayAccess, \Countable, \Itera
         unset($this->container['options'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['options']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['options']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/Accounting/Users.php
+++ b/lib/Models/Accounting/Users.php
@@ -159,9 +159,9 @@ class Users implements ModelInterface, ArrayAccess, \Countable, \IteratorAggrega
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Users implements ModelInterface, ArrayAccess, \Countable, \IteratorAggrega
         unset($this->container['users'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['users']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['users']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/Employees.php
+++ b/lib/Models/PayrollAu/Employees.php
@@ -159,9 +159,9 @@ class Employees implements ModelInterface, ArrayAccess, \Countable, \IteratorAgg
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Employees implements ModelInterface, ArrayAccess, \Countable, \IteratorAgg
         unset($this->container['employees'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['employees']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['employees']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/LeaveApplications.php
+++ b/lib/Models/PayrollAu/LeaveApplications.php
@@ -159,9 +159,9 @@ class LeaveApplications implements ModelInterface, ArrayAccess, \Countable, \Ite
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class LeaveApplications implements ModelInterface, ArrayAccess, \Countable, \Ite
         unset($this->container['leave_applications'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['leave_applications']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['leave_applications']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/LeaveLines.php
+++ b/lib/Models/PayrollAu/LeaveLines.php
@@ -160,9 +160,9 @@ class LeaveLines implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -289,18 +289,33 @@ class LeaveLines implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         unset($this->container['employee'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['employee']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['employee']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/PayItems.php
+++ b/lib/Models/PayrollAu/PayItems.php
@@ -159,9 +159,9 @@ class PayItems implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class PayItems implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['pay_items'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['pay_items']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['pay_items']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/PayRuns.php
+++ b/lib/Models/PayrollAu/PayRuns.php
@@ -159,9 +159,9 @@ class PayRuns implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class PayRuns implements ModelInterface, ArrayAccess, \Countable, \IteratorAggre
         unset($this->container['pay_runs'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['pay_runs']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['pay_runs']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/PayrollCalendars.php
+++ b/lib/Models/PayrollAu/PayrollCalendars.php
@@ -159,9 +159,9 @@ class PayrollCalendars implements ModelInterface, ArrayAccess, \Countable, \Iter
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class PayrollCalendars implements ModelInterface, ArrayAccess, \Countable, \Iter
         unset($this->container['payroll_calendars'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['payroll_calendars']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['payroll_calendars']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/Payslips.php
+++ b/lib/Models/PayrollAu/Payslips.php
@@ -159,9 +159,9 @@ class Payslips implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Payslips implements ModelInterface, ArrayAccess, \Countable, \IteratorAggr
         unset($this->container['payslips'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['payslips']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['payslips']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/ReimbursementLines.php
+++ b/lib/Models/PayrollAu/ReimbursementLines.php
@@ -160,9 +160,9 @@ class ReimbursementLines implements ModelInterface, ArrayAccess, \Countable, \It
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -289,18 +289,33 @@ class ReimbursementLines implements ModelInterface, ArrayAccess, \Countable, \It
         unset($this->container['reimbursement_lines'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['reimbursement_lines']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['reimbursement_lines']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/SuperFundProducts.php
+++ b/lib/Models/PayrollAu/SuperFundProducts.php
@@ -159,9 +159,9 @@ class SuperFundProducts implements ModelInterface, ArrayAccess, \Countable, \Ite
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class SuperFundProducts implements ModelInterface, ArrayAccess, \Countable, \Ite
         unset($this->container['super_fund_products'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['super_fund_products']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['super_fund_products']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/SuperFunds.php
+++ b/lib/Models/PayrollAu/SuperFunds.php
@@ -159,9 +159,9 @@ class SuperFunds implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class SuperFunds implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         unset($this->container['super_funds'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['super_funds']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['super_funds']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/lib/Models/PayrollAu/Timesheets.php
+++ b/lib/Models/PayrollAu/Timesheets.php
@@ -159,9 +159,9 @@ class Timesheets implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         return self::$openAPIModelName;
     }
 
-    
 
-    
+
+
 
     /**
      * Associative array for storing property values
@@ -288,18 +288,33 @@ class Timesheets implements ModelInterface, ArrayAccess, \Countable, \IteratorAg
         unset($this->container['timesheets'][$offset]);
     }
 
+    /**
+     * Gets count.
+     *
+     * @return int
+     */
     #[\ReturnTypeWillChange]
-    public function count() 
+    public function count()
     {
         return count($this->container['timesheets']);
     }
 
+    /**
+     * Gets iterator.
+     *
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
-    public function getIterator() 
+    public function getIterator()
     {
         return new \ArrayIterator($this->container['timesheets']);
     }
 
+    /**
+     * Gets the json presentation of the object.
+     *
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {


### PR DESCRIPTION
Symfony is giving deprecation warnings, should be able to resolve these by adding the missing PHPDocs.
```
[deprecation] User Deprecated: Method "Countable::count()" might add "int" as a native return type declaration in the future. Do the same in implementation "XeroAPI\XeroPHP\Models\Accounting\Invoices" now to avoid errors or add an explicit @return annotation to suppress this message.
[deprecation] User Deprecated: Method "IteratorAggregate::getIterator()" might add "\Traversable" as a native return type declaration in the future. Do the same in implementation "XeroAPI\XeroPHP\Models\Accounting\Invoices" now to avoid errors or add an explicit @return annotation to suppress this message.
[deprecation] User Deprecated: Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "XeroAPI\XeroPHP\Models\Accounting\Invoices" now to avoid errors or add an explicit @return annotation to suppress this message.
```