### PR TITLE
Securely decode access & ID tokens

### DIFF
--- a/lib/JWTClaims.php
+++ b/lib/JWTClaims.php
@@ -3,6 +3,7 @@ namespace XeroAPI\XeroPHP;
 
 use \Firebase\JWT\JWT;
 use \Firebase\JWT\JWK;
+use \GuzzleHttp\Client;
 
 class JWTClaims
 {
@@ -34,8 +35,9 @@ class JWTClaims
     * @return object $verifiedJWT
     */
     private function verify($token) {
-        $json = file_get_contents('https://identity.xero.com/.well-known/openid-configuration/jwks');
-        $jwks =  json_decode($json, true);
+        $client = new Client();
+        $response = $client->get('https://identity.xero.com/.well-known/openid-configuration/jwks');
+        $jwks = json_decode($response->getBody()->getContents(), true);
         $supportedAlgorithm = (object) ['alg'=>['RS256','ES256']];
         $verifiedJWT = JWT::decode($token, JWK::parseKeySet($jwks), $supportedAlgorithm);
 


### PR DESCRIPTION
This pull request changes the way the cryptographic keys are retrieved to improve the security of consumers by no longer requiring access to remote files, so the php configuration **allow_url_fopen** can now be disabled in order to prevent remote file inclusion, server-side request forgery, information disclosure and access control bypass attacks.